### PR TITLE
Replacing deprecated option 'SORTING_KEY for ENGINE_SORTING_KEY

### DIFF
--- a/datasources/current_events.datasource
+++ b/datasources/current_events.datasource
@@ -9,6 +9,6 @@ SCHEMA >
     json String
 
 ENGINE MergeTree
-SORTING_KEY timestamp
+ENGINE_SORTING_KEY timestamp
 
 

--- a/datasources/events.datasource
+++ b/datasources/events.datasource
@@ -13,6 +13,6 @@ SCHEMA >
     json String
 
 ENGINE MergeTree
-SORTING_KEY timestamp
+ENGINE_SORTING_KEY timestamp
 
 

--- a/datasources/top_products_view.datasource
+++ b/datasources/top_products_view.datasource
@@ -4,4 +4,4 @@ SCHEMA >
     total_sales AggregateFunction(sum, Float64)
 
 ENGINE AggregatingMergeTree
-SORTING_KEY date
+ENGINE_SORTING_KEY date


### PR DESCRIPTION
** [DEPRECATED]: The 'SORTING_KEY' keyword is deprecated, found at node 'default', you must use 'ENGINE_SORTING_KEY' instead. 'SORTING_KEY' will stop working after 2021-03-31.