### PR TITLE
Fix the test to match the guides documentation description

### DIFF
--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -14,7 +14,7 @@
     sql: |
         SELECT 1
           FROM top_products
-        HAVING COUNT() = 0
+        HAVING count() = 0
     pipe:
       name: top_products
       params:

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -12,14 +12,11 @@
     max_bytes_read: null
     max_time: null
     sql: |
-        SELECT 
-          date,
-          count() total
-        FROM top_products
-        GROUP BY date
-        HAVING total < 0
+        SELECT 1
+          FROM top_products
+        HAVING COUNT() = 0
     pipe:
       name: top_products
       params:
-        date_start: '2020-04-24'
-        date_end: '2020-04-25'
+        date_start: '2020-01-01'
+        date_end: '2020-12-31'


### PR DESCRIPTION
Now, The test checks that there are top products results in one year interval (2020) 

The documentation:

> Does not return empty top_10 products on 2023

Next step: Updating the documentation to reflect this change.